### PR TITLE
Bringing Absolute Imports & Linking Social Media

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+   "compilerOptions": {
+      "baseUrl": "src"
+   }
+}

--- a/src/app/containers.js
+++ b/src/app/containers.js
@@ -15,30 +15,25 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+
 import React, { useRef } from 'react';
-import { 
-    SignIn
-} from "../pages/signin/index";
 import {
-    BrowserRouter as Router, Route, Switch, Redirect 
+    BrowserRouter as Router, 
+    Route, 
+    Switch, 
+    Redirect 
 } from "react-router-dom";
-import {
-    Dashboard
-} from "../pages/dashboard/index";
-import AppNavigation from "../modules/navigation/navigation";
-import {
-    Paper
-} from '@material-ui/core';
-import {
-    useStyles
-} from "./styles";
-import Account from '../pages/account/';
-import Alert from '../modules/alert/alert';
-import { 
-    useDispatch 
-} from 'react-redux';
+import { Paper } from '@material-ui/core';
+import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
-import { loginUser } from '../redux/slices/user';
+
+import { Dashboard } from "pages/dashboard/index";
+import Account from 'pages/account/';
+import { SignIn } from "pages/signin/index";
+import AppNavigation from "modules/navigation/navigation";
+import { useStyles } from "./styles";
+import Alert from 'modules/alert/alert';
+import { loginUser } from 'redux/slices/user';
 
 const AppRouterSwitch = () => {
     const classes = useStyles();

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -22,7 +22,7 @@ import {
 } from "./containers";
 
 import { Provider } from 'react-redux';
-import store from '../redux/store';
+import store from 'redux/store';
 
 export const App = (props) => {   
     return (

--- a/src/modules/backend/backend.js
+++ b/src/modules/backend/backend.js
@@ -19,7 +19,7 @@
 import { 
     io 
 } from "socket.io-client";
-import { URL } from "../../config";
+import { URL } from "config";
 
 let accessToken = undefined;
 const url = URL

--- a/src/modules/navigation/sidebar.js
+++ b/src/modules/navigation/sidebar.js
@@ -89,9 +89,9 @@ const AppSideBar = ({ open, handleDrawerClose }) => {
     ], [history])
 
     const handleSocialIconClicked = useMemo(() => [
-        () => console.log('Social'),
-        () => console.log('Social'),
-        () => console.log('Social')
+        () => openSocial('https://www.instagram.com/sufst'),
+        () => openSocial('https://twitter.com/sufst'),
+        () => openSocial('https://github.com/orgs/sufst')
     ], [])
 
     const onIconClick = useCallback((index) => {
@@ -105,6 +105,11 @@ const AppSideBar = ({ open, handleDrawerClose }) => {
             handleSocialIconClicked[index]()
         }
     }, [handleSocialIconClicked])
+
+    const openSocial = (url) => {
+        const win = window.open(url, '_blank');
+        win.focus(); 
+    }
 
     return (
       <div>

--- a/src/modules/realtimegraphs/realtimegraphs.js
+++ b/src/modules/realtimegraphs/realtimegraphs.js
@@ -45,7 +45,7 @@ import {
 import { useSelector } from 'react-redux';
 import {
     updateSensorsMeta
-} from "../../redux/slices/sensors";
+} from "redux/slices/sensors";
 import { 
     useDispatch 
 } from 'react-redux';

--- a/src/pages/dashboard/header/containers.js
+++ b/src/pages/dashboard/header/containers.js
@@ -22,7 +22,7 @@ import Tab from '@material-ui/core/Tab';
 import {
     Session
 } from "../session/containers"
-import RealtimeSensorsGroupContainer from '../../../modules/realtimegraphs/realtimegraphs';
+import RealtimeSensorsGroupContainer from 'modules/realtimegraphs/realtimegraphs';
 import {
     v4 
 }from 'uuid';

--- a/src/pages/signin/containers.js
+++ b/src/pages/signin/containers.js
@@ -32,11 +32,11 @@ import {
     CreateAccountButton,
     FooterMessage
 } from "./components";
-import {
-    createUser
-} from "../../modules/backend/backend";
+
+import { createUser } from "modules/backend/backend";
+
 import { useDispatch } from 'react-redux';
-import { loginUser, setUser } from '../../redux/slices/user';
+import { loginUser, setUser } from 'redux/slices/user';
 
 const createAccountPayload = {
     isCreatingAccount: true

--- a/src/redux/middleware/alert.js
+++ b/src/redux/middleware/alert.js
@@ -19,8 +19,9 @@
 import { removeAlert } from "../slices/alert";
 
 export const alertMiddleware = storeAPI => next => action => {
-   
-    if (action.type === 'alert/show') {
+  
+    if (action.type === 'alert/showAlert') {
+        
         setTimeout(() => {
             next(removeAlert())
         }, action.payload.timeout)

--- a/src/redux/middleware/user.js
+++ b/src/redux/middleware/user.js
@@ -17,7 +17,7 @@
 */
 
 
-import { loginUser, sio } from "../../modules/backend/backend"
+import { loginUser, sio } from "modules/backend/backend"
 import { showAlert } from "../slices/alert";
 import { buildSensorsFromMeta, insertSensorsBulkData } from "../slices/sensors";
 import { setUser } from "../slices/user";


### PR DESCRIPTION
Adding the `src` directory as the root of the absolute pathing in the app. 

Import paths like: 

`import RealtimeSensorsGroupContainer from '../../../modules/realtimegraphs/realtimegraphs';`

have now been reduced to:

`import RealtimeSensorsGroupContainer from 'modules/realtimegraphs/realtimegraphs';`

Closes #17 
