### PR TITLE
Show 10 most recent sessions in sessions tab

### DIFF
--- a/src/pages/dashboard/session/components.tsx
+++ b/src/pages/dashboard/session/components.tsx
@@ -215,7 +215,8 @@ export const SensorChooser = (props: { allGroups: string[], selectedGroups: stri
 export const SessionTable = (props: { sessionData: SessionsGetResponse }) => {
     const classes = useStyles(); 
 
-    const sessionEntries = Object.entries(props.sessionData);
+    let sessionEntries = Object.entries(props.sessionData);
+    sessionEntries = sessionEntries.sort((a, b) => (b[1].creation - a[1].creation)).slice(0, 10);
     const info = sessionEntries.map(sessionEntry => {
         const name = sessionEntry[0]
         const sessionInfo = sessionEntry[1]


### PR DESCRIPTION
<!-- repos should copy this file into their .github folder -->
<!-- fill out (or delete) the checklist section as appropriate -->

### Changes
- [src/pages/dashboard/session/components.tsx](https://github.com/sufst/wireless-telemetry-gui/compare/56-featdashboard-update-dashboard-session-tab-table-to-only-include-latest-sessions?expand=1#diff-d69894ce04e6468d3043acc2594b0574079cef9c77f47377e458ec522aaded5e)
  - Sort the `sessionEntries` in descending order of `creation`
  - Slice the first 10 items and store them in `sessionEntries`