### PR TITLE
feat: add service worker to allow downloading as a PWA

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Telemetry",
+  "name": "SUFST Telemetry",
   "icons": [
     {
       "src": "favicon.ico",
@@ -19,6 +19,7 @@
     }
   ],
   "start_url": ".",
+  "scope": ".",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@
 
 // Imports
 import ReactDOM from 'react-dom';
-import { register } from 'serviceWorkerRegistration';
+import { registerServiceWorker } from 'serviceWorkerRegistration';
 import { App } from './app/index';
 import './index.css';
 
@@ -27,4 +27,4 @@ ReactDOM.render(
     document.getElementById('root')
 );
 
-register();
+registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@
 
 // Imports
 import ReactDOM from 'react-dom';
+import { register } from 'serviceWorkerRegistration';
 import { App } from './app/index';
 import './index.css';
 
@@ -26,3 +27,4 @@ ReactDOM.render(
     document.getElementById('root')
 );
 
+register();

--- a/src/modules/api/login.ts
+++ b/src/modules/api/login.ts
@@ -20,35 +20,41 @@ import { url } from "config";
 import { LoginUser } from "types/api/api";
 
 const handleLoginUser: LoginUser = async (username, password) => {
-    const response = await fetch(`http://${url}/login/${username}`, {
-        method: "POST",
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            password: password
+    try {
+        const response = await fetch(`http://${url}/login/${username}`, {
+            method: "POST",
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                password: password
+            })
         })
-    })
 
-    if(!response.ok) {
-        throw response.statusText; 
-    } 
+        if (!response.ok) {
+            throw response.statusText;
+        }
 
-    const data = await response.json(); 
-    return data;
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        throw new Error('offline');
+    }
 }
 
 export const loginUser = async (username: string, password: string) => {
 
-    let token = undefined; 
-    
+    let token = undefined;
+    let offline = false;
+
     try {
-        const data = await handleLoginUser(username, password); 
+        const data = await handleLoginUser(username, password);
         token = data.access_token
-    } 
-    catch(statusCode) {
-        console.error('Error Logging in:', statusCode);
     }
-    
-    return token; 
+    catch (error: any) {
+        console.error('Error Logging in:', error);
+        offline = error.message === 'offline';
+    }
+
+    return [token, offline];
 }

--- a/src/modules/api/sessions.ts
+++ b/src/modules/api/sessions.ts
@@ -26,24 +26,28 @@ import { SessionDetailGet, SessionCreate, SessionCreateFields, SessionsGet, Sess
  * @param fields Object housing the session metadata and sensors to be saved. 
  */
 const handleCreateSession: SessionCreate = async (accessToken, name, fields) => {
-  const response = await fetch(`http://${url}/sessions/${name}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: "Bearer " + accessToken,
-    },
-    body: JSON.stringify({
-      meta: fields.sessionMetadata,
-      sensors: fields.sessionSensors
+  try {
+    const response = await fetch(`http://${url}/sessions/${name}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + accessToken,
+      },
+      body: JSON.stringify({
+        meta: fields.sessionMetadata,
+        sensors: fields.sessionSensors
+      })
     })
-  })
 
-  if (!response.ok) {
-    throw response.statusText;
+    if (!response.ok) {
+      throw response.statusText;
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    throw new Error('offline');
   }
-
-  const data = await response.json();
-  return data;
 }
 
 export const createSession = async (accessToken: string, name: string, sessionMeta: object, sessionSensors: Array<string>) => {
@@ -55,11 +59,11 @@ export const createSession = async (accessToken: string, name: string, sessionMe
 
   try {
     const response = await handleCreateSession(accessToken, name, fields);
-    return response;
+    return [response, false];
   }
-  catch (statusText) {
-    console.log('Error creating new session: ', statusText);
-    return null;
+  catch (error: any) {
+    console.log('Error creating new session: ', error);
+    return [null, error.message === 'offline'];
   }
 }
 
@@ -69,32 +73,36 @@ export const createSession = async (accessToken: string, name: string, sessionMe
  * @param accessToken JWT authentication token 
  */
 const handleSessionStop = async (name: string, accessToken: string) => {
-  const response = await fetch(`http://${url}/sessions/${name}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: "Bearer " + accessToken,
-    },
-    body: JSON.stringify({
-      status: 'dead'
+  try {
+    const response = await fetch(`http://${url}/sessions/${name}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + accessToken,
+      },
+      body: JSON.stringify({
+        status: 'dead'
+      })
     })
-  })
 
-  if(!response.ok) {
-    throw response.statusText;
+    if (!response.ok) {
+      throw response.statusText;
+    }
+
+    return response;
+  } catch (error) {
+    throw new Error('offline');
   }
-
-  return response;
 }
 
 export const stopSession: SessionStop = async (name, token) => {
   try {
     const response = await handleSessionStop(name, token);
-    return response;
+    return [response, false];
   }
-  catch (statusText) {
-    console.log('Error Stopping session: ', statusText);
-    return null;
+  catch (error: any) {
+    console.error('Error Stopping session: ', error);
+    return [null, error.message === 'offline'];
   }
 }
 
@@ -102,29 +110,33 @@ export const stopSession: SessionStop = async (name, token) => {
  * Getting all the sessions in the database 
  */
 const handleGetAllSessions = async () => {
-  const response = await fetch(`http://${url}/sessions`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  })
+  try {
+    const response = await fetch(`http://${url}/sessions`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
 
-  if(!response.ok) {
-    throw response.statusText;
+    if (!response.ok) {
+      throw response.statusText;
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    throw new Error('offline');
   }
-
-  const data = await response.json();
-  return data;
 }
 
 export const getAllSessions: SessionsGet = async () => {
   try {
     const sessionResponse = await handleGetAllSessions();
-    return sessionResponse;
+    return [sessionResponse, false];
   }
-  catch (statusText) {
-    console.log('Error in Sessions GET: ', statusText);
-    return null;
+  catch (error: any) {
+    console.error('Error in Sessions GET: ', error);
+    return [null, error.message === 'offline'];
   }
 };
 
@@ -132,29 +144,33 @@ export const getAllSessions: SessionsGet = async () => {
  * Getting details of one of the sessions in the database 
  */
 const handleGetSessionDetail = async (name: String, accessToken: string) => {
-  const response = await fetch(`http://${url}/sessions/${name}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/zip",
-      Authorization: "Bearer " + accessToken,
-    },
-  })
+  try {
+    const response = await fetch(`http://${url}/sessions/${name}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/zip",
+        Authorization: "Bearer " + accessToken,
+      },
+    })
 
-  if (!response.ok) {
-    throw response.statusText;
+    if (!response.ok) {
+      throw response.statusText;
+    }
+
+    const data = await response.blob();
+    return data;
+  } catch (error) {
+    throw new Error('offline');
   }
-
-  const data = await response.blob();
-  return data;
 }
 
 export const getSessionDetail: SessionDetailGet = async (name: string, token: string) => {
   try {
     const sessionResponse = await handleGetSessionDetail(name, token);
-    return sessionResponse;
+    return [sessionResponse, false];
   }
-  catch (statusText) {
-    console.log('Error in Session Detail GET: ', statusText);
-    return null;
+  catch (error: any) {
+    console.error('Error in Session Detail GET: ', error);
+    return [null, error.message === 'offline'];
   }
 };

--- a/src/modules/navigation/InstallListItem.tsx
+++ b/src/modules/navigation/InstallListItem.tsx
@@ -1,3 +1,4 @@
+import Divider from '@material-ui/core/Divider';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -5,9 +6,9 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { useState } from 'react';
 
 
-const InstallListItem = (props: {key: string}) => {
+const InstallListItem = (props: { key: string }) => {
   const [show, setShow] = useState(false);
-  const [deferredPrompt, setDeferredPrompt ]: any = useState(null);
+  const [deferredPrompt, setDeferredPrompt]: any = useState(null);
   window.addEventListener('beforeinstallprompt', (event: Event) => {
     setShow(true);
     setDeferredPrompt(event);
@@ -24,10 +25,13 @@ const InstallListItem = (props: {key: string}) => {
   }
   if (show) {
     return (
-      <ListItem button key={props.key} onClick={click}>
-        <ListItemIcon><GetAppIcon /></ListItemIcon>
-        <ListItemText>Install</ListItemText>
-      </ListItem>
+      <>
+        <Divider />
+        <ListItem button key={props.key} onClick={click}>
+          <ListItemIcon><GetAppIcon /></ListItemIcon>
+          <ListItemText>Install</ListItemText>
+        </ListItem>
+      </>
     );
   } else {
     return <></>

--- a/src/modules/navigation/InstallListItem.tsx
+++ b/src/modules/navigation/InstallListItem.tsx
@@ -1,0 +1,37 @@
+import GetAppIcon from '@material-ui/icons/GetApp';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import { useState } from 'react';
+
+
+const InstallListItem = (props: {key: string}) => {
+  const [show, setShow] = useState(false);
+  const [deferredPrompt, setDeferredPrompt ]: any = useState(null);
+  window.addEventListener('beforeinstallprompt', (event: Event) => {
+    setShow(true);
+    setDeferredPrompt(event);
+  });
+  const click = async () => {
+    if (deferredPrompt !== null) {
+      deferredPrompt.prompt()
+      const { outcome } = await deferredPrompt.userChoice
+      if (outcome === 'accepted') {
+        setDeferredPrompt(null);
+        setShow(false);
+      }
+    }
+  }
+  if (show) {
+    return (
+      <ListItem button key={props.key} onClick={click}>
+        <ListItemIcon><GetAppIcon /></ListItemIcon>
+        <ListItemText>Install</ListItemText>
+      </ListItem>
+    );
+  } else {
+    return <></>
+  }
+}
+
+export default InstallListItem;

--- a/src/modules/navigation/InstallPwaListItem.tsx
+++ b/src/modules/navigation/InstallPwaListItem.tsx
@@ -6,14 +6,14 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { useState } from 'react';
 
 
-const InstallListItem = (props: { key: string }) => {
+const InstallPwaListItem = (props: { key: string }) => {
   const [show, setShow] = useState(false);
   const [deferredPrompt, setDeferredPrompt]: any = useState(null);
   window.addEventListener('beforeinstallprompt', (event: Event) => {
     setShow(true);
     setDeferredPrompt(event);
   });
-  const click = async () => {
+  const onButtonClick = async () => {
     if (deferredPrompt !== null) {
       deferredPrompt.prompt()
       const { outcome } = await deferredPrompt.userChoice
@@ -27,7 +27,7 @@ const InstallListItem = (props: { key: string }) => {
     return (
       <>
         <Divider />
-        <ListItem button key={props.key} onClick={click}>
+        <ListItem button key={props.key} onClick={onButtonClick}>
           <ListItemIcon><GetAppIcon /></ListItemIcon>
           <ListItemText>Install</ListItemText>
         </ListItem>
@@ -38,4 +38,4 @@ const InstallListItem = (props: { key: string }) => {
   }
 }
 
-export default InstallListItem;
+export default InstallPwaListItem;

--- a/src/modules/navigation/sidebar.tsx
+++ b/src/modules/navigation/sidebar.tsx
@@ -145,7 +145,6 @@ const AppSideBar = (props: { handleDrawerClose: () => void , open: boolean }) =>
             </List>
             <Divider />
             <List>
-                <InstallListItem key={'install'} />
                 {socialTitles.map((text, index) => (
                 <ListItem button key={text} onClick={() => onSocialClick(index)}>
                     <ListItemIcon >
@@ -155,6 +154,7 @@ const AppSideBar = (props: { handleDrawerClose: () => void , open: boolean }) =>
                 </ListItem>
                 ))}
             </List>
+            <InstallListItem key={'install'} />
          </Drawer>
       </div>
    )

--- a/src/modules/navigation/sidebar.tsx
+++ b/src/modules/navigation/sidebar.tsx
@@ -34,6 +34,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 
 import { useTheme } from '@material-ui/core/styles';
 import { useStyles } from './styles'
+import InstallListItem from './InstallListItem';
 
 // Material UI Icons Imports 
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
@@ -144,6 +145,7 @@ const AppSideBar = (props: { handleDrawerClose: () => void , open: boolean }) =>
             </List>
             <Divider />
             <List>
+                <InstallListItem key={'install'} />
                 {socialTitles.map((text, index) => (
                 <ListItem button key={text} onClick={() => onSocialClick(index)}>
                     <ListItemIcon >

--- a/src/modules/navigation/sidebar.tsx
+++ b/src/modules/navigation/sidebar.tsx
@@ -34,7 +34,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 
 import { useTheme } from '@material-ui/core/styles';
 import { useStyles } from './styles'
-import InstallListItem from './InstallListItem';
+import InstallPwaListItem from './InstallPwaListItem';
 
 // Material UI Icons Imports 
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
@@ -154,7 +154,7 @@ const AppSideBar = (props: { handleDrawerClose: () => void , open: boolean }) =>
                 </ListItem>
                 ))}
             </List>
-            <InstallListItem key={'install'} />
+            <InstallPwaListItem key={'install'} />
          </Drawer>
       </div>
    )

--- a/src/pages/dashboard/session/containers.tsx
+++ b/src/pages/dashboard/session/containers.tsx
@@ -70,9 +70,14 @@ export const SessionContainer = () => {
     const { privilege } = user; 
 
     const fetchAllSessions = useCallback(async () => {
-        const sessions = await getAllSessions();
-        setSessionData(sessions); 
-     }, [])
+        const [sessions] = await getAllSessions();
+        if (sessions) {
+            setSessionData(sessions);
+        } else {
+            const offlineAlert = createAlert(3000, "error", "alert", "Can't get sessions list as you are offline"); 
+            dispatch(showAlert(offlineAlert));
+        }
+     }, [dispatch])
 
     useEffect(() => {
         fetchAllSessions(); 

--- a/src/pages/sessions/components.tsx
+++ b/src/pages/sessions/components.tsx
@@ -45,8 +45,6 @@ export const SessionPaper = () => {
 export const SessionTable = (props: { sessionData: SessionsGetResponse }) => {
     const dispatch = useDispatch();
     const sessionEntries = Object.entries(props.sessionData);
-    console.log("sessionData",props.sessionData);
-    console.log("sessionEntries",sessionEntries);
     const info = sessionEntries.map(sessionEntry => {
         const name = sessionEntry[0]
         const sessionInfo = sessionEntry[1]

--- a/src/pages/sessions/containers.tsx
+++ b/src/pages/sessions/containers.tsx
@@ -29,8 +29,10 @@ export const SessionContainer = () => {
     const [sessionData, setSessionData] = useState({})
 
     const fetchAllSessions = useCallback(async () => {
-        const sessions = await getAllSessions();
-        setSessionData(sessions); 
+        const [sessions] = await getAllSessions();
+        if (sessions) {
+            setSessionData(sessions);
+        }
      }, [])
 
     useEffect(() => {

--- a/src/pages/sessions/containers.tsx
+++ b/src/pages/sessions/containers.tsx
@@ -18,11 +18,16 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Paper } from "@material-ui/core";
+import { useDispatch } from "react-redux";
 import { useStyles } from "../dashboard/session/styles";
 import { getAllSessions } from "modules/api/sessions";
 import { SessionTable, SessionPaper } from "./components";
+import { showAlert } from "redux/slices/alert";
+import { createAlert } from "modules/alert/alert";
 
 export const SessionContainer = () => {
+
+    const dispatch = useDispatch();
 
     const classes = useStyles(); 
     
@@ -32,8 +37,11 @@ export const SessionContainer = () => {
         const [sessions] = await getAllSessions();
         if (sessions) {
             setSessionData(sessions);
+        } else {
+            const offlineAlert = createAlert(3000, "error", "alert", "Can't get sessions list as you are offline"); 
+            dispatch(showAlert(offlineAlert));
         }
-     }, [])
+     }, [dispatch])
 
     useEffect(() => {
         fetchAllSessions(); 

--- a/src/redux/middleware/sessions.ts
+++ b/src/redux/middleware/sessions.ts
@@ -86,7 +86,7 @@ export const sessionMiddleware: Middleware<{}, any> =
     if (action.type === "session/getSessionDetail") {
         const [response, offline] = await getSessionDetail(action.payload.name, storeAPI.getState().user.accessToken);
         if (offline) {
-            const offlineAlert = createAlert(3000, "error", "alert", "Can't stop sessions as you are offline"); 
+            const offlineAlert = createAlert(3000, "error", "alert", "Can't download sessions as you are offline"); 
             storeAPI.dispatch(showAlert(offlineAlert));
         }
         else {

--- a/src/redux/middleware/sessions.ts
+++ b/src/redux/middleware/sessions.ts
@@ -41,12 +41,16 @@ export const sessionMiddleware: Middleware<{}, any> =
             condition: condition
         }; 
         
-        const response = await createSession(accessToken, name, sessionMeta, sensors); 
+        const [response, offline] = await createSession(accessToken, name, sessionMeta, sensors); 
 
         if (response) {
             const createSessionOkayAlert = createAlert(3000, "success", "alert", "New session created."); 
             storeAPI.dispatch(showAlert(createSessionOkayAlert));
         } 
+        else if (offline) {
+            const offlineAlert = createAlert(3000, "error", "alert", "Can't create a new session as you are offline"); 
+            storeAPI.dispatch(showAlert(offlineAlert))
+        }
         else {
             const createSessionFailedAlert = createAlert(3000, "error", "alert", "Can't create a new session..."); 
             storeAPI.dispatch(showAlert(createSessionFailedAlert))
@@ -61,12 +65,16 @@ export const sessionMiddleware: Middleware<{}, any> =
 
         console.log('Stopping session from middleware: ', name);
 
-        const response = await stopSession(name, accessToken); 
+        const [response, offline] = await stopSession(name, accessToken); 
 
         if (response) {
             const stopSessionOkayAlert = createAlert(3000, "success", "alert", "Session Stopped."); 
             storeAPI.dispatch(showAlert(stopSessionOkayAlert));
         } 
+        else if (offline) {
+            const offlineAlert = createAlert(3000, "error", "alert", "Can't stop session as you are offline"); 
+            storeAPI.dispatch(showAlert(offlineAlert));
+        }
         else {
             const stopSessionFailedAlert = createAlert(3000, "error", "alert", "Can't stop session..."); 
             storeAPI.dispatch(showAlert(stopSessionFailedAlert));
@@ -76,8 +84,14 @@ export const sessionMiddleware: Middleware<{}, any> =
     }
 
     if (action.type === "session/getSessionDetail") {
-        const response = await getSessionDetail(action.payload.name, storeAPI.getState().user.accessToken);
-        download(response, action.payload.name + ".zip", "application/zip");
+        const [response, offline] = await getSessionDetail(action.payload.name, storeAPI.getState().user.accessToken);
+        if (offline) {
+            const offlineAlert = createAlert(3000, "error", "alert", "Can't stop sessions as you are offline"); 
+            storeAPI.dispatch(showAlert(offlineAlert));
+        }
+        else {
+            download(response, action.payload.name + ".zip", "application/zip");
+        }
     }
 
     return next(action);

--- a/src/redux/middleware/user.ts
+++ b/src/redux/middleware/user.ts
@@ -38,9 +38,13 @@ export const userMiddleware: Middleware<{}, any> =
     if (action.type === "user/loginUser") {
       const { username, password } = action.payload;
 
-      const accessToken = await loginUser(username, password); 
+      const [accessToken, offline] = await loginUser(username, password); 
 
-      if (accessToken === undefined) {
+      if (offline) {
+        const offlineAlert = createAlert(3000, "warning", "alert", "Cannot login as you are offline");
+        storeAPI.dispatch(showAlert(offlineAlert));
+        return next(action);
+      } else if (accessToken === undefined) {
         const loginFailedAlert = createAlert(3000, "error", "alert", "Login Failed :( Make sure your credentials are correct!"); 
         storeAPI.dispatch(showAlert(loginFailedAlert));
         return next(action);

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-restricted-globals */
+import { clientsClaim } from 'workbox-core';
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { CacheFirst } from 'workbox-strategies';
+
+clientsClaim();
+
+// Precache "src" files and serve them CacheFirst
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Set up App Shell-style routing, so that all navigation requests
+// are fulfilled with your index.html shell. Learn more at
+// https://developers.google.com/web/fundamentals/architecture/app-shell
+const fileExtensionRegexp = new RegExp('/[^/?]+\\.[^/]+$');
+registerRoute(
+  // Return false to exempt requests from being fulfilled by index.html.
+  ({ request, url }) => {
+    // If this isn't a navigation, skip.
+    if (request.mode !== 'navigate') {
+      return false;
+    }
+
+    // If this is a URL that starts with /_, skip.
+    if (url.pathname.startsWith('/_')) {
+      return false;
+    }
+    
+    // If this looks like a URL for a resource, because it contains // a file extension, skip.
+    if (url.pathname.match(fileExtensionRegexp)) {
+      return false;
+    }
+
+    // Return true to signal that we want to use the handler.
+    return true;
+  },
+  createHandlerBoundToURL(process.env.PUBLIC_URL + '/index.html')
+);
+
+// Images: serve cached version, or from network if not in cache
+registerRoute(
+  ({ request, sameOrigin }) => sameOrigin && request.destination === 'image',
+  new CacheFirst({
+    cacheName: 'images',
+  })
+);
+
+// Manifest: serve cached version, or from network if not in cache
+registerRoute(
+  ({ request, sameOrigin }) => sameOrigin && request.destination === 'manifest',
+  new CacheFirst({
+    cacheName: 'manifest',
+  })
+);
+
+// This allows the web app to trigger skipWaiting via
+// registration.waiting.postMessage({type: 'SKIP_WAITING'})
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -39,7 +39,7 @@ registerRoute(
 
 // Images: serve cached version, or from network if not in cache
 registerRoute(
-  ({ request, sameOrigin }) => sameOrigin && request.destination === 'image',
+  ({ event }) => event.request.destination === 'image',
   new CacheFirst({
     cacheName: 'images',
   })
@@ -47,7 +47,7 @@ registerRoute(
 
 // Manifest: serve cached version, or from network if not in cache
 registerRoute(
-  ({ request, sameOrigin }) => sameOrigin && request.destination === 'manifest',
+  ({ event }) => event.request.destination === 'manifest',
   new CacheFirst({
     cacheName: 'manifest',
   })

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -6,7 +6,7 @@ const isLocalhost: boolean = Boolean(
   window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
-export const register = (config: any) => {
+export const registerServiceWorker = (config: any) => {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
@@ -112,7 +112,7 @@ const checkValidServiceWorker = (swUrl: string, config: any) => {
     });
 }
 
-export const unregister = () => {
+export const unregisterServiceWorker = () => {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready
       .then((registration) => {

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -1,0 +1,125 @@
+const isLocalhost: boolean = Boolean(
+  window.location.hostname === 'localhost' ||
+  // [::1] is the IPv6 localhost address.
+  window.location.hostname === '[::1]' ||
+  // 127.0.0.0/8 are considered localhost for IPv4.
+  window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+);
+
+export const register = (config: any) => {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
+      return;
+    }
+
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+
+      if (isLocalhost) {
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl, config);
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => {
+          console.log(
+            'This web app is being served cache-first by a service ' +
+            'worker. To learn more, visit https://cra.link/PWA'
+          );
+        });
+      } else {
+        // Is not localhost. Just register service worker
+        registerValidSW(swUrl, config);
+      }
+    });
+  }
+}
+
+const registerValidSW = (swUrl: string, config: any) => {
+  navigator.serviceWorker
+    .register(swUrl)
+    .then((registration) => {
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        if (installingWorker == null) {
+          return;
+        }
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === 'installed') {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the updated precached content has been fetched,
+              // but the previous service worker will still serve the older
+              // content until all client tabs are closed.
+              console.log(
+                'New content is available and will be used when all ' +
+                'tabs for this page are closed. See https://cra.link/PWA.'
+              );
+
+              // Execute callback
+              if (config && config.onUpdate) {
+                config.onUpdate(registration);
+              }
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // "Content is cached for offline use." message.
+              console.log('Content is cached for offline use.');
+
+              // Execute callback
+              if (config && config.onSuccess) {
+                config.onSuccess(registration);
+              }
+            }
+          }
+        };
+      };
+    })
+    .catch((error) => {
+      console.error('Error during service worker registration:', error);
+    });
+}
+
+const checkValidServiceWorker = (swUrl: string, config: any) => {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl, {
+    headers: { 'Service-Worker': 'script' },
+  })
+    .then((response) => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      const contentType = response.headers.get('content-type');
+      if (
+        response.status === 404 ||
+        (contentType != null && contentType.indexOf('javascript') === -1)
+      ) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then((registration) => {
+          registration.unregister().then(() => {
+            window.location.reload();
+          });
+        });
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl, config);
+      }
+    })
+    .catch(() => {
+      console.log('No internet connection found. App is running in offline mode.');
+    });
+}
+
+export const unregister = () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        registration.unregister();
+      })
+      .catch((error) => {
+        console.error(error.message);
+      });
+  }
+}


### PR DESCRIPTION
### Changes
- Added service worker
- Register service worker in /src/index.js
- Change app name in manifest
- Added install button to sidebar (when install is available)
- When running offline, alert messages are displayed when API requests are attempted

### Additional Notes
- The service worker is only registered in production builds so code files don't have to be deleted from the cache before their changes can be applied in the browser when in development mode
 - You can use the browser in incognito/guest mode to try out the app with the service worker without causing issues with caching
   - The app can't be installed in incognito/guest mode. When trying in the browser in a normal profile, make sure you delete all the caches and unregister the service worker in the Application tab of DevTools before returning to the development version!
 - Service workers are only served over HTTPS or from localhost (the app will not be installable over non-localhost HTTP!)
 - If updates are available, close the app and reopen it for the changes to be applied
   - Disabling the cache in the Network tab of DevTools doesn't impact the service worker, so content will still be served from the application cache
 - Icons (defined in the manifest) are required for the PWA to be installable. I used the default React ones for testing, but the whole set of icons can be generated from a site like [PWABuilder](https://www.pwabuilder.com/imageGenerator)
 - I used the [Create React App PWA Template](https://github.com/cra-template/pwa/tree/main/packages/cra-template-pwa/template/src) as a starting point for the service worker related files
